### PR TITLE
feat(pre-commit): broken links check, renovate for pre-commit

### DIFF
--- a/.github/markdown-links.json
+++ b/.github/markdown-links.json
@@ -1,0 +1,17 @@
+{
+    "projectBaseUrl":"${workspaceFolder}",
+    "ignorePatterns": [
+      {
+        "pattern": "^http(s?)://localhost"
+      }
+    ],
+    "replacementPatterns": [
+    ],
+    "httpHeaders": [
+    ],
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+  }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
     "config:recommended",
     ":dependencyDashboard",
     ":semanticCommits",
+    ":enablePreCommit",
     ":docker"
   ],
   "automerge": false,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,11 @@ repos:
         entry: .pre-commit-hooks/update_readme_version.sh
         types: [text]
         stages: [commit, push, manual]
+
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.1 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+    hooks:
+      - id: markdown-link-check
+        args: [-q, -c .github/markdown-links.json]
+
 ...

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build-images](https://img.shields.io/badge/Camunda-FC5D0D)](https://www.camunda.com/)
 [![build-images](https://github.com/camunda/keycloak/actions/workflows/build-images.yml/badge.svg?branch=main)](https://github.com/camunda/keycloak/actions/workflows/build-images.yml)
 [![Docker image](https://img.shields.io/badge/docker.io%2Fcamunda%2Fkeycloak-e4f0fb?logo=docker&label=docker%20amd64,arm64)](https://hub.docker.com/r/camunda/keycloak)
-[![Licence](https://img.shields.io/github/license/camunda/keycloak)](https://github.com/camunda/keycloak/blob/master/LICENSE)
+[![Licence](https://img.shields.io/github/license/camunda/keycloak)](https://github.com/camunda/keycloak/blob/main/LICENSE)
 
 This Docker image provides a generic Keycloak setup. It also includes an optional AWS wrapper, allowing for the use of AWS Identity and Access Management (IAM) Roles for Service Accounts (IRSA) for database authentication.
 


### PR DESCRIPTION
This pre-commit ensure that our README.md does not have broken links.

The renovate config has also been updated to check pre-commit.

As the repository is currently private, the pre-commit link fails, this PR should be merged after https://github.com/camunda/keycloak/issues/26 is completed.