### PR TITLE
feat(postgres): switch postgres image from docker hub to ecr.aws

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -383,7 +383,7 @@ jobs:
 
           KEYCLOAK_LOG_LEVEL: "INFO,software.amazon.jdbc:FINEST"
 
-          COMPOSE_POSTGRES_IMAGE: "postgres:${{ env.postgres_version }}"
+          COMPOSE_POSTGRES_IMAGE: "public.ecr.aws/docker/library/postgres:${{ env.postgres_version }}"
           COMPOSE_POSTGRES_DEPLOY_REPLICAS: "${{ matrix.runner_desc.postgres_replicas }}"
           COMPOSE_KEYCLOAK_DEPENDS_ON: "${{ env.compose_keycloak_depends_on }}"
           COMPOSE_KEYCLOAK_VOLUME_1: "${{ env.compose_keycloak_volume_1 || '/dev/null:/dummynull1' }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   postgres:
-      image: ${COMPOSE_POSTGRES_IMAGE:-postgres}
+      image: ${COMPOSE_POSTGRES_IMAGE:-public.ecr.aws/docker/library/postgres:latest}
       volumes:
         - postgres_data:/var/lib/postgresql/data
       environment:


### PR DESCRIPTION
Docker hub rate limiting api prevents pull of the images in CI: https://github.com/camunda/keycloak/actions/runs/8295281514/job/22702181569

Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit

This failure caused the last release not to be released.
- [x] rerun the last release after merging