### PR TITLE
doc: broken link in maintenance

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -31,7 +31,7 @@ _Nothing referenced yet._
 
 ### Downstream Dependencies: things that depend on this project
 
-- **Distribution Team**: Utilizes this project in various aspects, including the [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/values-latest.yaml).
+- **Distribution Team**: Utilizes this project in various aspects, including the [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-latest/values-latest.yaml).
 
 ## Actions
 


### PR DESCRIPTION
same link broke two weeks ago already.

I'm not sure why we link to the values yml file instead of just the repo itself. 