### PR TITLE
fix(test): compose command wasnt properly parsed

### DIFF
--- a/.github/actions/compose/healthy.sh
+++ b/.github/actions/compose/healthy.sh
@@ -5,7 +5,7 @@
 # Edge case; Self-hosted runners don't support "docker compose" yet even though on v2
 VERSION=$(docker-compose version --short)
 
-if [[ "$VERSION" =~ ^1\.[0-9]+\.[0-9]+ ]]; then
+if [[ "$VERSION" =~ ^1\.[0-9]+\.[0-9]+ || -z "${VERSION}" ]]; then
     # if docker-compose is v1, we're setting it to docker compose, which should be v2
     echo "Deteceted v1, setting to v2"
     DOCKER_COMMAND="docker compose -f ${FILE} ${COMPOSE_FLAGS}"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -533,7 +533,7 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-latest
-    if: failure()
+    if: failure() && github.event_name == 'schedule'
     needs:
       - publish-image
       - read-build-image-output
@@ -543,7 +543,6 @@ jobs:
     steps:
       - name: Notify in Slack in case of failure
         id: slack-notification
-        if: github.event_name == 'schedule'
         uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@44ea6ed8c70214b8ef629c292ae0e84710179633 # main
         with:
           vault_addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
likely related to compose v1 deprecation

I've tested it and will go ahead and merge it as we currently don't have any reviewers present.
Before the fix it wouldn't do the health check and now it does it properly again. So we don't have a potential race condition that the DB isn't ready yet.