### PR TITLE
fix(tests): remove version attribute docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 volumes:
     postgres_data:
         driver: local


### PR DESCRIPTION
this attribute is outdated and reported as a warning
see "Start test environment" in https://github.com/camunda/keycloak/actions/runs/13628133268/job/38090190283