### PR TITLE
fix: revert keycloak from 26.2 to 26.1

### DIFF
--- a/keycloak-26/bases.yml
+++ b/keycloak-26/bases.yml
@@ -16,4 +16,4 @@ sources:
         # skopeo --override-os linux inspect docker://registry.camunda.cloud/vendor-ee/keycloak:<tag> --raw | skopeo manifest-digest /dev/stdin
         image:
             repository: registry.camunda.cloud/vendor-ee/keycloak
-            tag: 26.2.5-debian-12-r3@sha256:17aff522766636a7a315188481662b4bf4ce846731c06da261ba5b6a95fea70d
+            tag: 26.1.4-debian-12-r4@sha256:cfbcd98a0032cf82dcf53a3565dd3800af1ca20444d81186869ed2038b8a5a74


### PR DESCRIPTION
This PR temporarly reverts keycloak to 26.1 to unlock usage in camunda chart for enterprise. It will not affects the hub version and not removed previous version