### PR TITLE
fix: apply renovate to dockerfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,24 @@
       "matchUpdateTypes": ["major"],
       "enabled": false,
     },
+    // this applies the same mechanism but to Dockerfile (e.g. identity which uses latest)
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "all non-major keycloak",
+      "groupSlug": "all-non-major-keycloak",
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["keycloak-*/Dockerfile"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$",
+      "enabled": true,
+      "addLabels": ["dependencies", "docker"],
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["keycloak-*/Dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+    },
   ],
   hostRules: [
     {


### PR DESCRIPTION
This PR fixes the patch of the Dockerfile, such as identity:latest that are currently not groupped