### PR TITLE
fix: override image description label to remove emojis

### DIFF
--- a/keycloak-23/Dockerfile
+++ b/keycloak-23/Dockerfile
@@ -75,7 +75,6 @@ COPY --from=builder /opt/bitnami/keycloak/themes/identity /opt/bitnami/keycloak/
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -87,6 +86,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak bitnami with AWS wrapper." \
       io.k8s.display-name="keycloak-bitnami" \
       description="Keycloak bitnami with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-23/Dockerfile.quay
+++ b/keycloak-23/Dockerfile.quay
@@ -60,7 +60,6 @@ COPY --chown=keycloak:keycloak --from=minimal-build /opt/keycloak/themes/identit
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -72,6 +71,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak official with AWS wrapper." \
       io.k8s.display-name="keycloak-quay" \
       description="Keycloak official with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-24/Dockerfile
+++ b/keycloak-24/Dockerfile
@@ -75,7 +75,6 @@ COPY --from=builder /opt/bitnami/keycloak/themes/identity /opt/bitnami/keycloak/
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -87,6 +86,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak bitnami with AWS wrapper." \
       io.k8s.display-name="keycloak-bitnami" \
       description="Keycloak bitnami with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-24/Dockerfile.quay
+++ b/keycloak-24/Dockerfile.quay
@@ -82,7 +82,6 @@ RUN if [ "$BUILD_OPTIMIZED" = "true" ]; then \
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -94,6 +93,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak official with AWS wrapper." \
       io.k8s.display-name="keycloak-quay" \
       description="Keycloak official with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-25/Dockerfile
+++ b/keycloak-25/Dockerfile
@@ -76,7 +76,6 @@ COPY --chown=1001:1000 --from=builder /opt/bitnami/keycloak/themes/identity /opt
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -88,6 +87,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak bitnami with AWS wrapper." \
       io.k8s.display-name="keycloak-bitnami" \
       description="Keycloak bitnami with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-25/Dockerfile.quay
+++ b/keycloak-25/Dockerfile.quay
@@ -82,7 +82,6 @@ RUN if [ "$BUILD_OPTIMIZED" = "true" ]; then \
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -94,6 +93,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak official with AWS wrapper." \
       io.k8s.display-name="keycloak-quay" \
       description="Keycloak official with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-26/Dockerfile
+++ b/keycloak-26/Dockerfile
@@ -79,7 +79,6 @@ USER keycloak
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -91,6 +90,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak bitnami with AWS wrapper." \
       io.k8s.display-name="keycloak-bitnami" \
       description="Keycloak bitnami with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \

--- a/keycloak-26/Dockerfile.quay
+++ b/keycloak-26/Dockerfile.quay
@@ -82,7 +82,6 @@ RUN if [ "$BUILD_OPTIMIZED" = "true" ]; then \
       # cpu and ram allocation reference: https://www.keycloak.org/high-availability/multi-cluster/concepts-memory-and-cpu-sizing
       # the following labels are generated at buildtime - see https://github.com/docker/metadata-action
       # org.opencontainers.image.title
-      # org.opencontainers.image.description
       # org.opencontainers.image.url
       # org.opencontainers.image.created
       # org.opencontainers.image.revision
@@ -94,6 +93,7 @@ LABEL maintainer="Camunda" \
       io.k8s.description="Keycloak official with AWS wrapper." \
       io.k8s.display-name="keycloak-quay" \
       description="Keycloak official with AWS JDBC wrapper." \
+      org.opencontainers.image.description="Camunda's Keycloak Docker image: AWS-wrapped and PostgreSQL-compatible" \
       jdbc.aws-jdbc-wrapper.version="${AWS_JDBC_WRAPPER_VERSION}" \
       org.opencontainers.image.authors="Camunda" \
       org.opencontainers.image.vendor="Camunda" \


### PR DESCRIPTION
Explicitly set org.opencontainers.image.description in all Dockerfiles to prevent the emoji-laden GitHub repo description (injected by docker/metadata-action) from breaking enterprise registries like JFrog.