### PR TITLE
feat(ci): release keycloak CVE patches daily

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -88,6 +88,20 @@
       "matchUpdateTypes": ["major"],
       "enabled": false,
     },
+    // The check-changes job of release-keycloak-upgrade triggers on any
+    // keycloak-*/Dockerfile* change (it greps the `Dockerfile` prefix, so
+    // Dockerfile.quay is included). Ensure digest/pin/patch updates in ALL of
+    // those files (e.g. the almalinux base OS and identity theme layers in
+    // Dockerfile.quay) are detected daily too, instead of the Sundays-only
+    // schedule from the shared preset. Schedule-only override: versioning and
+    // grouping for the plain Dockerfile are handled by the dedicated rule above.
+    {
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["keycloak-*/Dockerfile*"],
+      "matchUpdateTypes": ["pin", "digest", "patch"],
+      "schedule": ["at any time"],
+    },
   ],
   hostRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,7 +76,9 @@
       "enabled": true,
       "addLabels": ["dependencies", "docker"],
       // Same daily-update override as the bases.yml rule so CVE patches in the
-      // Keycloak Dockerfiles are not held back to Sundays by the shared preset.
+      // keycloak-*/Dockerfile files are not held back to Sundays by the shared
+      // preset. This rule only matches the exact keycloak-*/Dockerfile path via
+      // matchFileNames (Dockerfile.quay and other variants are not in scope).
       "schedule": ["at any time"],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,10 @@
       "enabled": true,
       "addLabels": ["dependencies", "docker"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      // Override the shared preset which restricts patch/pin/digest updates to Sundays.
+      // Keycloak base image CVE patches must be picked up daily so the daily
+      // release-keycloak-upgrade workflow can publish them promptly.
+      "schedule": ["at any time"],
     },
     {
       "matchManagers": ["helm-values"],
@@ -71,6 +75,9 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$",
       "enabled": true,
       "addLabels": ["dependencies", "docker"],
+      // Same daily-update override as the bases.yml rule so CVE patches in the
+      // Keycloak Dockerfiles are not held back to Sundays by the shared preset.
+      "schedule": ["at any time"],
     },
     {
       "matchManagers": ["dockerfile"],

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -1,11 +1,13 @@
 ---
-# desc: create a GitHub release when Keycloak versions are upgraded by Renovate
+# desc: create a daily GitHub release when Keycloak base images change (e.g. CVE patches picked up by Renovate)
 name: release-keycloak-upgrade
 
 on:
     workflow_dispatch:
     schedule:
-        - cron: 0 8 * * 1
+        # Daily so CVE patches landing in keycloak-*/bases.yml or Dockerfile* are released promptly.
+        # The check-changes job guards against empty releases on days with no relevant change.
+        - cron: 0 8 * * *
 
 # Scheduled workflows run on the default branch only.
 # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -5,7 +5,8 @@ name: release-keycloak-upgrade
 on:
     workflow_dispatch:
     schedule:
-        # Daily so CVE patches landing in keycloak-*/bases.yml or Dockerfile* are released promptly.
+        # Daily so CVE patches landing in a keycloak-<N>/bases.yml or keycloak-<N>/Dockerfile* file
+        # (the patterns matched by the check-changes job) are released promptly.
         # The check-changes job guards against empty releases on days with no relevant change.
         - cron: 0 8 * * *
 


### PR DESCRIPTION
## What

Make the Keycloak CVE-patch release pipeline run **daily** instead of weekly.

### Changes
- **\`.github/workflows/release-keycloak-upgrade.yml\`**: cron \`0 8 * * 1\` (Mondays) → \`0 8 * * *\` (daily). The \`check-changes\` job already guards against empty releases on days with no relevant \`bases.yml\`/\`Dockerfile\` change.
- **\`.github/renovate.json5\`**: add \`"schedule": ["at any time"]\` to the two rules covering \`keycloak-*/bases.yml\` and \`keycloak-*/Dockerfile\`. The shared \`infraex-common-config\` preset restricts \`patch\`/\`pin\`/\`digest\` updates to **Sundays only**; since Keycloak CVE patches land as \`digest\`/\`patch\` bumps, this override lets Renovate detect them every day so they can feed the daily release.

## Why

CVE patches on Keycloak base images should reach customers quickly. Previously the release could only happen once a week (Monday), and Renovate would only surface the relevant digest/patch PRs on Sundays — so a CVE fix could wait up to a week before publication.

## End-to-end flow

1. Renovate (daily) detects a base-image CVE patch in \`keycloak-*/bases.yml\` → opens a digest/patch PR
2. Auto-merge workflow merges it once checks pass
3. \`release-keycloak-upgrade\` (daily) detects the change and creates a dated tag
4. \`build-images\` publishes on tag

## Validation

- \`renovate-config-validator\` passes (also run as a pre-commit hook on this commit).