### PR TITLE
fix(renovate): track vendor-ee/keycloak via docker datasource (custom datasource can't pin digests)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,17 +65,6 @@
       "matchFileNames": ["keycloak-*/bases.yml"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>debian-\\d+)-r(?<build>\\d+))?$",
     },
-    // The vendor-ee/keycloak (prem) base image is sourced from the
-    // bitnami-keycloak-camunda custom datasource (see customManagers below): the
-    // complete upstream tag list published by camunda-deployment-references, with
-    // no registry.camunda.cloud credentials needed. Disable the docker/helm-values
-    // tracking for it so it is not bumped twice.
-    {
-      "matchManagers": ["helm-values"],
-      "matchPackageNames": ["registry.camunda.cloud/vendor-ee/keycloak"],
-      "matchFileNames": ["keycloak-*/bases.yml"],
-      "enabled": false,
-    },
     // this applies the same mechanism but to Dockerfile (e.g. identity which uses latest)
     {
       "matchManagers": ["dockerfile"],
@@ -112,24 +101,6 @@
       "matchFileNames": ["keycloak-*/Dockerfile*"],
       "matchUpdateTypes": ["pin", "digest", "patch"],
       "schedule": ["at any time"],
-    },
-  ],
-  customManagers: [
-    {
-      // Source the Bitnami Premium Keycloak base image (vendor-ee) from the
-      // bitnami-keycloak-camunda custom datasource (defined in
-      // camunda/infraex-common-config, inherited via `extends`): the complete
-      // upstream tag list published by camunda-deployment-references, including
-      // tags from before the November 2025 vendor migration, with no registry
-      // credentials required. The feed exposes newDigest, so the @sha256 stays pinned.
-      customType: 'regex',
-      managerFilePatterns: ['/keycloak-.*/bases\\.ya?ml$/'],
-      matchStrings: [
-        'repository: registry\\.camunda\\.cloud/vendor-ee/keycloak\\s+tag: (?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?',
-      ],
-      depNameTemplate: 'keycloak',
-      datasourceTemplate: 'custom.bitnami-keycloak-camunda',
-      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>debian-\\d+)-r(?<build>\\d+))?$',
     },
   ],
   hostRules: [


### PR DESCRIPTION
## Problem

The Mend Renovate run reports a **repo problem** and drops **all** keycloak base-image updates:

```
WARN: Package lookup failures
  "Could not determine new digest for update (custom.bitnami-keycloak-camunda package keycloak)"
  files: keycloak-23/bases.yml … keycloak-26/bases.yml
→ "updates": []
```

## Root cause

#590 switched the `vendor-ee/keycloak` (prem) base image to the `bitnami-keycloak-camunda` **custom datasource**. But `keycloak-*/bases.yml` pins the image by **digest** (`tag@sha256:…`). Custom datasources don't implement digest lookup (`getDigest`), so when Renovate computes a version bump it can't resolve the new `@sha256` and **discards the whole update**. The feed's `newDigest` field only lets Renovate *add* a digest, not *refresh* one on a version change.

## Fix

Revert the prem image to the **docker datasource** against `registry.camunda.cloud` (as `bitnamilegacy` and `quay` already are): it resolves both the tag and the digest, so updates flow again and the digest stays pinned. Removes the `customManager` and the disable rule added in #590; the existing `hostRule` + bitnami versioning rule already cover it.

## Note

The published feed (camunda-deployment-references) is unaffected and still consumed where there is **no** digest pin (e.g. `camunda-platform-helm` postgresql). The custom-datasource approach is simply incompatible with digest-pinned files like `bases.yml`.

Follow-up to #590.