### PR TITLE
fix(quay): remove conflicting AWS SDK Netty from optimized providers

### DIFF
--- a/.github/scripts/build-check/check_providers.py
+++ b/.github/scripts/build-check/check_providers.py
@@ -95,10 +95,10 @@ def main():
         success = check_bitnami_config(args.image_name)
 
     if success:
-        print(f"✅ All required AWS components found in {args.image_type} image")
+        print(f"✅ Provider/config check passed for {args.image_type} image")
         sys.exit(0)
     else:
-        print(f"❌ Some required AWS components missing in {args.image_type} image")
+        print(f"❌ Provider/config check failed for {args.image_type} image (missing required or forbidden component present)")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/.github/scripts/build-check/check_providers.py
+++ b/.github/scripts/build-check/check_providers.py
@@ -10,6 +10,15 @@ REQUIRED_AWS_COMPONENTS = [
     "apache-client"
 ]
 
+# Components that must NOT ship in the Quay optimized providers directory.
+# The AWS SDK pulls in its own (older) Netty through netty-nio-client; if it lands in
+# /opt/keycloak/providers it shadows Keycloak's bundled, Vert.x-aligned Netty and breaks
+# HTTP/2 cleartext (H2C) upgrades at runtime with a NoSuchMethodError.
+# See https://github.com/camunda/camunda-deployment-references/issues/2809
+FORBIDDEN_QUAY_PROVIDERS = [
+    "netty"
+]
+
 def run_docker_command(image_name, command):
     """Run a docker command and return the output"""
     try:
@@ -40,6 +49,14 @@ def check_quay_providers(image_name):
         else:
             print(f"❌ {component} not found")
             all_found = False
+
+    # Ensure no conflicting components leaked into the providers directory
+    for component in FORBIDDEN_QUAY_PROVIDERS:
+        if component in output:
+            print(f"❌ forbidden component '{component}' found in providers (must be removed)")
+            all_found = False
+        else:
+            print(f"✅ {component} correctly absent")
 
     return all_found
 

--- a/keycloak-23/Dockerfile.quay
+++ b/keycloak-23/Dockerfile.quay
@@ -25,13 +25,23 @@ RUN microdnf install -y maven && \
 # Create directories and download dependencies
 RUN mkdir -p /opt/keycloak/providers /opt/keycloak/themes/identity
 
-# Download and process Maven dependencies
+# Download and process Maven dependencies.
+#
+# The AWS Advanced JDBC Wrapper transitively pulls in the AWS SDK asynchronous HTTP client
+# (software.amazon.awssdk:netty-nio-client) and its Netty stack. Keycloak already bundles a
+# Vert.x-aligned Netty under /opt/keycloak/lib; this older copy in /opt/keycloak/providers
+# shadows it and breaks HTTP/2 cleartext (H2C) upgrades at runtime with
+# "NoSuchMethodError ...AbstractHttp2ConnectionHandlerBuilder". The wrapper only uses the
+# synchronous apache-client, so these Netty jars are unused and are removed to keep the
+# bundled, version-aligned Netty on the classpath.
+# See https://github.com/camunda/camunda-deployment-references/issues/2809
 # hadolint ignore=DL3003
 RUN curl -fL "https://repo1.maven.org/maven2/software/amazon/jdbc/aws-advanced-jdbc-wrapper/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.pom" \
     -o /tmp/pom.xml && \
     mkdir -p /tmp/.m2 && \
     cd /tmp && mvn -f pom.xml -Dmaven.repo.local=/tmp/.m2/repository dependency:copy-dependencies -DoutputDirectory=/opt/keycloak/providers && \
     cp /tmp/.m2/repository/software/amazon/*/*/*/*.jar /opt/keycloak/providers/ && \
+    rm -f /opt/keycloak/providers/netty-*.jar && \
     curl -fL "https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar" \
     -o /opt/keycloak/providers/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar
 

--- a/keycloak-24/Dockerfile.quay
+++ b/keycloak-24/Dockerfile.quay
@@ -25,13 +25,23 @@ RUN microdnf install -y maven && \
 # Create directories and download dependencies
 RUN mkdir -p /opt/keycloak/providers /opt/keycloak/themes/identity
 
-# Download and process Maven dependencies
+# Download and process Maven dependencies.
+#
+# The AWS Advanced JDBC Wrapper transitively pulls in the AWS SDK asynchronous HTTP client
+# (software.amazon.awssdk:netty-nio-client) and its Netty stack. Keycloak already bundles a
+# Vert.x-aligned Netty under /opt/keycloak/lib; this older copy in /opt/keycloak/providers
+# shadows it and breaks HTTP/2 cleartext (H2C) upgrades at runtime with
+# "NoSuchMethodError ...AbstractHttp2ConnectionHandlerBuilder". The wrapper only uses the
+# synchronous apache-client, so these Netty jars are unused and are removed to keep the
+# bundled, version-aligned Netty on the classpath.
+# See https://github.com/camunda/camunda-deployment-references/issues/2809
 # hadolint ignore=DL3003
 RUN curl -fL "https://repo1.maven.org/maven2/software/amazon/jdbc/aws-advanced-jdbc-wrapper/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.pom" \
     -o /tmp/pom.xml && \
     mkdir -p /tmp/.m2 && \
     cd /tmp && mvn -f pom.xml -Dmaven.repo.local=/tmp/.m2/repository dependency:copy-dependencies -DoutputDirectory=/opt/keycloak/providers && \
     cp /tmp/.m2/repository/software/amazon/*/*/*/*.jar /opt/keycloak/providers/ && \
+    rm -f /opt/keycloak/providers/netty-*.jar && \
     curl -fL "https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar" \
     -o /opt/keycloak/providers/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar
 

--- a/keycloak-25/Dockerfile.quay
+++ b/keycloak-25/Dockerfile.quay
@@ -25,13 +25,23 @@ RUN microdnf install -y maven && \
 # Create directories and download dependencies
 RUN mkdir -p /opt/keycloak/providers /opt/keycloak/themes/identity
 
-# Download and process Maven dependencies
+# Download and process Maven dependencies.
+#
+# The AWS Advanced JDBC Wrapper transitively pulls in the AWS SDK asynchronous HTTP client
+# (software.amazon.awssdk:netty-nio-client) and its Netty stack. Keycloak already bundles a
+# Vert.x-aligned Netty under /opt/keycloak/lib; this older copy in /opt/keycloak/providers
+# shadows it and breaks HTTP/2 cleartext (H2C) upgrades at runtime with
+# "NoSuchMethodError ...AbstractHttp2ConnectionHandlerBuilder". The wrapper only uses the
+# synchronous apache-client, so these Netty jars are unused and are removed to keep the
+# bundled, version-aligned Netty on the classpath.
+# See https://github.com/camunda/camunda-deployment-references/issues/2809
 # hadolint ignore=DL3003
 RUN curl -fL "https://repo1.maven.org/maven2/software/amazon/jdbc/aws-advanced-jdbc-wrapper/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.pom" \
     -o /tmp/pom.xml && \
     mkdir -p /tmp/.m2 && \
     cd /tmp && mvn -f pom.xml -Dmaven.repo.local=/tmp/.m2/repository dependency:copy-dependencies -DoutputDirectory=/opt/keycloak/providers && \
     cp /tmp/.m2/repository/software/amazon/*/*/*/*.jar /opt/keycloak/providers/ && \
+    rm -f /opt/keycloak/providers/netty-*.jar && \
     curl -fL "https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar" \
     -o /opt/keycloak/providers/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar
 

--- a/keycloak-26/Dockerfile.quay
+++ b/keycloak-26/Dockerfile.quay
@@ -25,13 +25,23 @@ RUN microdnf install -y maven && \
 # Create directories and download dependencies
 RUN mkdir -p /opt/keycloak/providers /opt/keycloak/themes/identity
 
-# Download and process Maven dependencies
+# Download and process Maven dependencies.
+#
+# The AWS Advanced JDBC Wrapper transitively pulls in the AWS SDK asynchronous HTTP client
+# (software.amazon.awssdk:netty-nio-client) and its Netty stack. Keycloak already bundles a
+# Vert.x-aligned Netty under /opt/keycloak/lib; this older copy in /opt/keycloak/providers
+# shadows it and breaks HTTP/2 cleartext (H2C) upgrades at runtime with
+# "NoSuchMethodError ...AbstractHttp2ConnectionHandlerBuilder". The wrapper only uses the
+# synchronous apache-client, so these Netty jars are unused and are removed to keep the
+# bundled, version-aligned Netty on the classpath.
+# See https://github.com/camunda/camunda-deployment-references/issues/2809
 # hadolint ignore=DL3003
 RUN curl -fL "https://repo1.maven.org/maven2/software/amazon/jdbc/aws-advanced-jdbc-wrapper/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.pom" \
     -o /tmp/pom.xml && \
     mkdir -p /tmp/.m2 && \
     cd /tmp && mvn -f pom.xml -Dmaven.repo.local=/tmp/.m2/repository dependency:copy-dependencies -DoutputDirectory=/opt/keycloak/providers && \
     cp /tmp/.m2/repository/software/amazon/*/*/*/*.jar /opt/keycloak/providers/ && \
+    rm -f /opt/keycloak/providers/netty-*.jar && \
     curl -fL "https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/${AWS_JDBC_WRAPPER_VERSION}/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar" \
     -o /opt/keycloak/providers/aws-advanced-jdbc-wrapper-${AWS_JDBC_WRAPPER_VERSION}.jar
 


### PR DESCRIPTION
## Problem

The `camunda/keycloak:quay-optimized-*` images crash on any HTTP/2 cleartext (H2C) upgrade with a `NoSuchMethodError`, which makes Keycloak unreachable over plain-HTTP port-forward access (no ingress, no TLS). A browser sending `Upgrade: h2c` is enough to trigger it:

```
java.lang.NoSuchMethodError: 'io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder
  io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder.encoderEnforceMaxRstFramesPerWindow(int, int)'
    at io.vertx.core.http.impl.VertxHttp2ConnectionHandlerBuilder...
    at io.vertx.core.http.impl.Http1xOrH2CHandler...
```

Reported in camunda/camunda-deployment-references#2809.

## Root cause

`Dockerfile.quay` fills `/opt/keycloak/providers` with the AWS Advanced JDBC Wrapper **and its full transitive dependency tree** via `mvn dependency:copy-dependencies`. The AWS SDK `services` POM declares a runtime dependency on the async HTTP client `netty-nio-client`, which drags a whole Netty stack into `providers`:

```
netty-codec-http2-4.1.108.Final.jar   <-- shadows the bundled Netty
netty-handler-4.1.108.Final.jar
netty-nio-client-2.25.70.jar
...
```

Keycloak already bundles a Netty aligned with its Vert.x under `/opt/keycloak/lib` (e.g. `netty-codec-http2-4.1.130.Final` with `vertx-core-4.5.25`). The older Netty in `providers` shadows it, and Vert.x's H2C handler then calls into a Netty it wasn't compiled against, failing with `NoSuchMethodError`.

## Fix

The wrapper only uses the **synchronous** `apache-client`, so the async Netty stack is unused. Drop it from `providers` right after the dependency copy:

```dockerfile
rm -f /opt/keycloak/providers/netty-*.jar
```

- Applied to all optimized images: `keycloak-23/24/25/26/Dockerfile.quay`.
- Regression guard added to `check_providers.py` (already run in CI): fails if any `netty` jar reappears in `providers`, while still asserting `apache-client` / `sts` / `aws-advanced-jdbc-wrapper` are present.
- The bitnami/hub and prem images are **not** affected — their `Dockerfile` only copies `software.amazon.*` jars, never `io.netty.*`.

## Validation

Built the real `keycloak-26/Dockerfile.quay` with this change on the current base image and hit it with `curl --http2` (H2C upgrade):

| Image | `curl --http2` (H2C) | Server |
| --- | --- | --- |
| current `quay-optimized-26.6.1` | empty reply, connection dropped | `NoSuchMethodError` |
| this PR | HTTP/2, request served | clean, 0 errors |

- `providers` after build: no `netty*` jars; `apache-client`, `sts`, `aws-advanced-jdbc-wrapper` still present.
- `check_providers.py` passes on the fixed image, fails on the current one.
- `hadolint` passes on all four Dockerfiles.

Refs: camunda/camunda-deployment-references#2809
