### PR TITLE
[READY] fix(renovate): track Dockerfile ARG versions (aws-advanced-jdbc-wrapper)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        '/(^|/)Dockerfile[^/]*$/',
+        '/(^|/)keycloak-[^/]+/Dockerfile[^/]*$/',
       ],
       "matchStrings": [
         '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+ARG \\w+?_VERSION=(?<currentValue>\\S+)',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,21 @@
       '/(^|/)bases\\.ya?ml$/',
     ],
   },
+  // The shared infraex-common-config customManager reads `# renovate:` annotations in
+  // yaml/sh/go/tf/tool-versions/justfile but NOT Dockerfiles, so annotated ARGs such as
+  // AWS_JDBC_WRAPPER_VERSION were never picked up and stayed frozen at their initial value.
+  // This repo-local customManager covers keycloak-*/Dockerfile* so those ARGs are tracked.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        '/(^|/)Dockerfile[^/]*$/',
+      ],
+      "matchStrings": [
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+ARG \\w+?_VERSION=(?<currentValue>\\S+)',
+      ],
+    },
+  ],
   "separateMajorMinor": true,
   "packageRules": [
     {


### PR DESCRIPTION
## Problem

`AWS_JDBC_WRAPPER_VERSION` in `keycloak-*/Dockerfile*` carries a `# renovate:` annotation, but it has been **frozen at `2.3.9` since it was introduced (#422)** while base images kept updating — latest is `4.1.0`.

Root cause: the regex `customManager` that interprets `# renovate: datasource=… depName=…` annotations comes from the shared `infraex-common-config` preset, and its `managerFilePatterns` only cover `**.yaml/.yml/.sh/.go/.tf/.tfvars/.tool-versions/justfile` — **not Dockerfiles**. The built-in `dockerfile` manager updates `FROM` images but does not read arbitrary-ARG annotations, so the wrapper ARG was silently never tracked.

## Change

Add a repo-local `customManager` scoped to `keycloak-*/Dockerfile*` so the annotated ARG is picked up again.

- Regex validated against all 8 Dockerfiles (16 matches): `datasource=github-tags`, `depName=aws/aws-advanced-jdbc-wrapper`, `currentValue=2.3.9`.
- The repo has **no** non-Dockerfile `# renovate:` annotations, so this does not shadow anything from the shared preset.
- Validated with `renovate-config-validator` on the CI-pinned renovate `43.205.0` (config validates successfully; the pre-commit hook passes).

## Notes

- Once merged, Renovate will open a (major) `2.3.9 → 4.1.x` bump PR. That upgrade is reviewed on its own — 4.x is a major with potential breaking changes — and is **orthogonal** to the H2C/Netty fix in #596.
- Alternative root fix: add a Dockerfile pattern to the shared `infraex-common-config` customManager (fixes every consuming repo at once, broader blast radius). Happy to open that instead/as well if preferred.
