### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.0.1

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -86,7 +86,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
             - name: Import secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -211,7 +211,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
             - name: Set Keycloak Image Name
               id: set-keycloak-image-name
@@ -309,7 +309,7 @@ jobs:
                   libreadline-dev tk tk-dev
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
             - name: Set Keycloak Image Name
               id: set-keycloak-image-name
@@ -582,7 +582,7 @@ jobs:
                   buildx-install: true
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
             - name: Import secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -783,7 +783,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
     call-todo-checker:
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Notify in Slack in case of failure
               id: slack-notification
               if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
     lint:
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -148,7 +148,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
     - repo: https://github.com/camunda/infraex-common-config
-      rev: 1.8.0 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      rev: 2.0.1 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
       hooks:
           - id: update-action-readmes-docker
 


### PR DESCRIPTION
Re-pins every `camunda/infraex-common-config` reusable workflow and composite action from `1.8.0` to `2.0.1` (`4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5`), and moves the `.pre-commit-config.yaml` hook to the same tag.

- Release: https://github.com/camunda/infraex-common-config/releases/tag/2.0.1
- Diff: https://github.com/camunda/infraex-common-config/compare/1.8.0...2.0.1