### PR TITLE
ci: pin infra-global-github-actions to its SHA-pinned revision (partial)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -144,7 +144,7 @@ jobs:
 
             - name: Build image using Camunda docker build
               id: build-image-step
-              uses: camunda/infra-global-github-actions/build-docker-image@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
+              uses: camunda/infra-global-github-actions/build-docker-image@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   registry_host: ${{ env.CONTAINER_REGISTRY_CI }}
                   registry_username: ${{ steps.secrets.outputs.MACHINE_USR }}
@@ -573,7 +573,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Install if required common software tooling
-              uses: camunda/infra-global-github-actions/common-tooling@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
+              uses: camunda/infra-global-github-actions/common-tooling@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   node-enabled: false
                   java-enabled: false
@@ -758,7 +758,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   error-messages: |
                       lost communication with the server

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -59,7 +59,7 @@ jobs:
         steps:
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common


### PR DESCRIPTION
## What this fixes

`camunda/infra-global-github-actions` was pinned here at `8f6fae58` (2026-07-25), a revision predating that repository's own SHA pinning. This moves all 4 references to `14f6353d`, its current `main`.

That repairs the tree behind `generate-github-app-token-from-vault-secrets`, pinned upstream in camunda/infra-global-github-actions#779.

## What this does NOT fix, and why

`build-images` stays red. Verified on this branch: it still fails at **Set up job** with the exact same annotation as before the bump.

```
The actions docker/metadata-action@v6, docker/setup-qemu-action@v4,
docker/setup-buildx-action@v4, docker/login-action@v4, and
docker/build-push-action@v7 are not allowed in camunda/keycloak because all
actions must be pinned to a full-length commit SHA.
```

`build-docker-image/action.yml` at `14f6353d`, the tip of upstream `main`, is still unpinned:

```
131:    uses: docker/metadata-action@v6
155:    uses: docker/setup-qemu-action@v4
162:    uses: docker/setup-buildx-action@v4
176:    uses: docker/login-action@v4
189:    uses: docker/build-push-action@v7
```

`common-tooling` and `rerun-failed-run` are in the same state upstream. GitHub evaluates the pinning requirement over the **entire** dependency tree, so no revision a caller can pick will unblock `build-images`. It has to be fixed in `camunda/infra-global-github-actions`.

That work is already in flight: camunda/infra-global-github-actions#781, *ci: pin third-party GitHub Actions to commit SHAs with zizmor enforcement*, which touches `build-docker-image/action.yml`, `common-tooling/action.yml` and `rerun-failed-run/action.yml`. Once it lands, a follow-up here re-pinning to the merge commit finishes the job.

## Why merge this anyway

It removes 4 of the stale references now, keeps this repository aligned with the rest of the fleet, and makes the follow-up a one-line SHA change instead of a rediscovery.

## Validation

`pre-commit run --all-files` passes, `actionlint` and `yamllint` included.