### PR TITLE
ci: re-pin infra-global-github-actions to its SHA-pinned revision

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -144,7 +144,7 @@ jobs:
 
             - name: Build image using Camunda docker build
               id: build-image-step
-              uses: camunda/infra-global-github-actions/build-docker-image@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/build-docker-image@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   registry_host: ${{ env.CONTAINER_REGISTRY_CI }}
                   registry_username: ${{ steps.secrets.outputs.MACHINE_USR }}
@@ -573,7 +573,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
             - name: Install if required common software tooling
-              uses: camunda/infra-global-github-actions/common-tooling@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/common-tooling@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   node-enabled: false
                   java-enabled: false
@@ -758,7 +758,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   error-messages: |
                       lost communication with the server

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -59,7 +59,7 @@ jobs:
         steps:
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common


### PR DESCRIPTION
Re-pins `camunda/infra-global-github-actions` to `3ec04ae6fd02074f0253dedf6850bb9b50eb59d3`, the merge commit of camunda/infra-global-github-actions#781.

That PR pins every action in the dependency tree of those composite actions, **including the `actions/*` namespace**. GitHub's **Require actions to be pinned to a full-length commit SHA** grants no namespace exemption:

> all actions must be pinned to a full-length commit SHA to be used. This includes actions from your organization and actions authored by GitHub.

It is evaluated over the **whole** dependency tree at `Set up job`, so until now no revision a caller could pick would have helped — the fix had to happen upstream.

Verified at `3ec04ae6`: the dependency tree of every composite action this repository consumes resolves to SHA pins only.

Affects 4 references. This is what unblocks `build-images`, which #629 explicitly could not: `build-docker-image` resolved `docker/metadata-action@v6`, `docker/setup-qemu-action@v4`, `docker/setup-buildx-action@v4`, `docker/login-action@v4` and `docker/build-push-action@v7`, all unpinned, and `common-tooling` resolved `actions/setup-node@v7` and `actions/setup-python@v7`.

Consumed actions verified clean at `3ec04ae6`: `build-docker-image`, `common-tooling`, `generate-github-app-token-from-vault-secrets`, `rerun-failed-run`.