### PR TITLE
ci: pin the hadolint image and document the DL3066 exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,16 @@ repos:
           - id: detect-private-key
 
     - repo: https://github.com/hadolint/hadolint
-      rev: v2.14.0
+      rev: v2.15.1
       hooks:
+          # The upstream hook entry is `ghcr.io/hadolint/hadolint hadolint`, with no tag,
+          # so it resolves to :latest and the linter version drifts away from the `rev`
+          # above. That is how 2.15.1 arrived unannounced and turned every branch red
+          # without a commit: it enables DL3066, which 2.14.0 did not report.
+          # Pinning the image by digest keeps the linter on the version this `rev` names,
+          # and lets Renovate move both together.
           - id: hadolint-docker
+            entry: ghcr.io/hadolint/hadolint@sha256:32dac94127fd60b7b7e3fbfc65e1383b9b5e25c9bfd7b8536de7a539fe68a12d hadolint
 
     - repo: https://github.com/rhysd/actionlint
       rev: v1.7.12

--- a/keycloak-26/Dockerfile
+++ b/keycloak-26/Dockerfile
@@ -37,6 +37,12 @@ RUN mkdir /home/keycloak && chown keycloak:keycloak /home/keycloak && \
 
 COPY --from=identity /app/keycloak-theme/ /opt/bitnami/keycloak/themes/identity
 
+# The keycloak user id is not stable across the three bases this image is built from,
+# so it is referenced by name rather than by number. Verified on the pinned digests:
+# keycloak-25's bitnami base has keycloak=1001, while all three 26 bases -- bitnami,
+# vendor-ee and quay -- have keycloak=1000. Hardcoding a number here would run as a
+# uid that does not exist in at least one of them.
+# hadolint ignore=DL3066
 USER keycloak
 
 WORKDIR /home/keycloak
@@ -82,6 +88,12 @@ USER 0
 RUN chown keycloak:keycloak -R /opt/bitnami/keycloak/ && \
     chmod +x /opt/bitnami/scripts/*.sh
 
+# The keycloak user id is not stable across the three bases this image is built from,
+# so it is referenced by name rather than by number. Verified on the pinned digests:
+# keycloak-25's bitnami base has keycloak=1001, while all three 26 bases -- bitnami,
+# vendor-ee and quay -- have keycloak=1000. Hardcoding a number here would run as a
+# uid that does not exist in at least one of them.
+# hadolint ignore=DL3066
 USER keycloak
 
 # common, k8s, openshift and OCI labels:


### PR DESCRIPTION
`Lint Dockerfiles` went red on every branch at once, with no commit touching a Dockerfile.

## Root cause: the linter was never pinned

```yaml
- repo: https://github.com/hadolint/hadolint
  rev: v2.14.0
  hooks:
      - id: hadolint-docker
```

`rev` pins the *hook repository*. The hook's upstream entry is:

```yaml
entry: ghcr.io/hadolint/hadolint hadolint
```

No tag, so it resolves to `:latest`. The linter version was free to drift away from the `rev` right above it.

`latest` moved **2.14.0 -> 2.15.1**, which enables `DL3066`. Reproduced exactly:

```
$ docker image inspect ghcr.io/hadolint/hadolint:latest   # stale local copy
  hadolint@sha256:27086352…   ->  2.14.0   ->  exit 0

$ docker pull ghcr.io/hadolint/hadolint:latest            # what the runner got
  hadolint@sha256:32dac941…   ->  2.15.1
  keycloak-26/Dockerfile:40 DL3066 info: Non-numeric user-id may not be resolvable by host system
  keycloak-26/Dockerfile:85 DL3066 info: Non-numeric user-id may not be resolvable by host system
  exit 1
```

That is why it reproduced on CI and not locally: a cached image.

## Fix 1 — pin the image by digest

`entry` is overridden to `ghcr.io/hadolint/hadolint@sha256:32dac941…`, and `rev` moves to `v2.15.1` so both name the same version. Moving forward rather than pinning back to 2.14.0: this adopts the new rule instead of dodging it, and Renovate can now move the two together.

## Fix 2 — DL3066 is a false positive here, documented as such

`keycloak-26` is built against **three** bases, and the `keycloak` uid is not the same in all of them. Verified against the pinned digests in `bases.yml`:

| Dockerfile | base | `keycloak` uid |
|---|---|---|
| `keycloak-25` | `bitnamilegacy/keycloak` 25.0.6 | **1001** |
| `keycloak-26` | `bitnamilegacy/keycloak` 26.3.3 | **1000** |
| `keycloak-26` | `vendor-ee/keycloak` 26.7.0 | **1000** |
| `keycloak-26` | `quay.io/keycloak/keycloak` 26.7.0 | **1000** |

The uid changed between the 25 and 26 base images. That is why `keycloak-26` uses `USER keycloak` where 23/24/25 use `USER 1001` — the name is stable across the three bases, the number is not. "Fixing" DL3066 by hardcoding a number would make the image run as a uid that does not exist in at least one base.

So the two `USER keycloak` lines get `# hadolint ignore=DL3066` with the measurements recorded next to them, matching the existing `# hadolint ignore=DL3008` precedent in the same file.

## Verification

- `pre-commit run --all-files` green.
- Negative test, the suppression is doing real work rather than the pin hiding the finding: removing the two `# hadolint ignore=DL3066` lines makes the hook `Failed` again on the pinned 2.15.1.

## Not related to the SHA-pinning PRs

This surfaced on #630 but is independent of it — it also hit `renovate/patch-grouped` at the same time, and #630 changes no Dockerfile.
