### PR TITLE
ci: use the matrix-outputs-read action to pin its dependencies

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -189,7 +189,7 @@ jobs:
         runs-on: ubuntu-24.04
         needs: [build-image]
         steps:
-            - uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # v1
+            - uses: camunda/infra-global-github-actions/matrix-outputs-read@32a6e03de12f6c9c08a2e0590bb5aef2d69e9d6c # main
               id: read
               with:
                   matrix-step-name: build-image


### PR DESCRIPTION
Same defect as `camunda/camunda-deployment-references` #3020, found by sweeping every repository for the action after fixing it there.

## Problem

`read-build-image-output` is refused at **Set up job**, before any step runs:

```
The actions dcarbone/install-jq-action@v2.1.0 and actions/download-artifact@v4
are not allowed in camunda/keycloak because all actions must be pinned to a
full-length commit SHA.
```

Neither action appears in this repository. They come from `cloudposse/github-action-matrix-outputs-read`, which is pinned by SHA here — but GitHub evaluates the requirement over the **whole** dependency tree, and that action's own `action.yml` is unpinned:

```yaml
- name: 'Setup jq'
  uses: dcarbone/install-jq-action@v2.1.0
- uses: actions/download-artifact@v4
```

There is no revision to move to: upstream's last release is **1.0.0, 2024-02-28**, and its `main` is still unpinned today.

## Change

One line. The reference is swapped for `camunda/infra-global-github-actions/matrix-outputs-read`, added in camunda/infra-global-github-actions#784. Same jq program, same input, same output, same step `id`, so the `outputs.result` mapping below it is untouched.

`cloudposse/github-action-matrix-outputs-write` on line 179 is **left alone**: at its pinned revision it contains no `uses:` at all, so it is unaffected.

## Prerequisite already satisfied

The action requires that the calling job does **not** run `actions/checkout`: it downloads every artifact into the working directory and then walks it with `find . -maxdepth 2`, so a checkout would put repository files inside that search path. `read-build-image-output` has no checkout, so nothing else changes.

## What the shared action adds

Beyond pinning both references, review on #784 hardened three things that the upstream action does not do:

- the merged object is never echoed to the job log — here it carries the image names, elsewhere kubeconfigs;
- `matrix-step-name` is validated and encoded before being interpolated into a workflow command;
- an artifact name matching nothing fails at the source, where jq previously reduced it to `{}` and handed downstream jobs an empty object.

The upstream `Setup jq` step is dropped rather than pinned: it force-installed jq 1.6 through the very action that dragged in the unpinned references, while the runners already ship jq and both versions produce byte-identical output for this program.

## Verification

- No unpinned `uses:` left anywhere in the repository.
- `actionlint` and `yamllint` pass.
