### PR TITLE
ci: scope GITHUB_TOKEN to least privilege in workflows [ready]

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -32,6 +32,14 @@ env:
     CONTAINER_REGISTRY_CI: registry.camunda.cloud
     CONTAINER_IMAGE_NAME_CI: team-infrastructure-experience/keycloak
 
+# The repository default is `default_workflow_permissions: write`, so without this block every
+# job below runs with a read/write GITHUB_TOKEN. None of them needs it: the registry logins use
+# Vault AppRole credentials, the matrix outputs travel as artifacts (ACTIONS_RUNTIME_TOKEN, not
+# GITHUB_TOKEN) and `rerun-failed-jobs` dispatches with a dedicated GitHub App token.
+# Jobs that need more than this escalate individually.
+permissions:
+    contents: read
+
 jobs:
     triage:
         runs-on: ubuntu-24.04
@@ -772,6 +780,12 @@ jobs:
 
     notify-on-failure:
         runs-on: ubuntu-latest
+        # `report-failure-on-slack` reads the open `silence: <workflow>` issues of this repository
+        # to decide whether the alert is muted. Without `issues: read` it warns and alerts anyway,
+        # which silently defeats the silencing mechanism.
+        permissions:
+            contents: read
+            issues: read
         if: failure() && (fromJSON(github.run_attempt) >= 3 || inputs.notify_back_error_message != '') && github.event_name == 'schedule'
         needs:
             - publish-image

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,10 +10,19 @@ on:
         paths:
             - .github/workflows/links.yml
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: links-check
         runs-on: ubuntu-latest
+        # `issues: write` is for the scheduled failure path only: `create-issue-from-file` opens the
+        # "Link Checker Report" issue, and `report-failure-on-slack` reads the `silence: <workflow>`
+        # issues of this repository to decide whether the alert is muted.
+        permissions:
+            contents: read
+            issues: write
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -17,8 +17,12 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: false
 
+# The `release` job never writes through GITHUB_TOKEN: both the checkout and every `gh` call
+# there run with the GitHub App token minted from Vault, which is also what lets the pushed tag
+# trigger `build-images.yml` (GITHUB_TOKEN-created refs do not trigger workflows).
+# `check-changes` only reads, so a read-only GITHUB_TOKEN is enough for the whole workflow.
 permissions:
-    contents: write
+    contents: read
 
 jobs:
     check-changes:
@@ -142,6 +146,12 @@ jobs:
         name: Report failures
         if: failure()
         runs-on: ubuntu-latest
+        # `report-failure-on-slack` reads the open `silence: <workflow>` issues of this repository
+        # to decide whether the alert is muted. Without `issues: read` it warns and alerts anyway,
+        # which silently defeats the silencing mechanism.
+        permissions:
+            contents: read
+            issues: read
         needs:
             - check-changes
             - release


### PR DESCRIPTION
Follow-up to the review of #622, which scoped `build-image` and `test-postgres-integ` down to `contents: read` and proved in CI that it is sufficient. That left 5 of 7 jobs in `build-images.yml` on the repository default, so this PR finishes the job and applies the same treatment to the other two workflows that define their jobs inline.

## Problem

The repository default is `default_workflow_permissions: write`. Every job without an explicit `permissions` block therefore gets a GITHUB_TOKEN that can push to `main`, create releases, open issues and comment on pull requests. In `build-images.yml` that token is handed to ~35 jobs per run, several of which execute third-party actions and pull external content (base images, `pom.xml` from `raw.githubusercontent.com`, PyPI dependencies).

## What the token is actually used for

Nothing, in the jobs being restricted:

- registry logins (`docker/login-action`) use Vault AppRole credentials, never GITHUB_TOKEN;
- matrix outputs travel as artifacts, authenticated with `ACTIONS_RUNTIME_TOKEN`;
- `rerun-failed-jobs` dispatches through `camunda/infra-global-github-actions/rerun-failed-run`, which mints its own GitHub App token from Vault;
- in `release-keycloak-upgrade.yml`, the `release` job passes the App token explicitly to both `actions/checkout` (`token:`) and every `gh` call (`GH_TOKEN:`). That is not incidental: a tag created with GITHUB_TOKEN would not trigger `build-images.yml`, which is the entire point of the release. `check-changes` only runs `gh release list`, a read.

The only genuine needs are on the failure paths, and they are granted per job.

## Change

| workflow | workflow-level | per-job escalation |
| --- | --- | --- |
| `build-images.yml` | `contents: read` (new) | `notify-on-failure`: `issues: read` |
| `links.yml` | `contents: read` (new) | `links-check`: `issues: write` |
| `release-keycloak-upgrade.yml` | `contents: write` -> `contents: read` | `report-failure`: `issues: read` |

The `issues` grants are not cosmetic. `create-issue-from-file` opens the "Link Checker Report" issue on scheduled failures, and `report-failure-on-slack` reads the open `silence: <workflow>` issues to decide whether an alert is muted — without `issues: read` it logs a warning and alerts anyway, so a silenced workflow would start paging again. Both were covered by the implicit write default until now.

## Deliberately untouched

`lint.yml` and `internal_global_pr_todo_checker.yml` call reusable workflows from `infraex-common-config`. Those declare their own permissions (`lint-global.yml` is already `contents: read` with the auto-fix commit isolated behind an App token), and a caller-level `permissions` block would cap the callee rather than complement it.

## Interaction with #622

No conflict. #622 adds job-level blocks to `build-image` and `test-postgres-integ`, which stay necessary there for `id-token: write` — OIDC is never granted by the repository default. Whichever lands first, the other applies cleanly.

## Verification

- Every `uses:` reachable from the restricted jobs was checked for GITHUB_TOKEN usage: `common-tooling` and `asdf-install-tooling` only pass `github.token` to `setup-node`/`setup-python` for public distribution downloads; `matrix-outputs-read` is `download-artifact`; `build-docker-image` is docker-only.
- `actionlint`, `yamllint` and `yamlfmt` pass via pre-commit.
- CI on this branch exercises `list-keycloak-versions`, `build-image`, `read-build-image-output`, `test-base-image` and `test-postgres-integ` on push, plus the whole of `links.yml`. `publish-image` is tag-only, so it is covered by static review: checkout, Vault AppRole logins and `docker buildx imagetools`, none of which touch GITHUB_TOKEN.
