### PR TITLE
ci: add zizmor to pre-commit and fix its high findings [ready]

### DIFF
--- a/.github/actions/extract-version-vars/action.yml
+++ b/.github/actions/extract-version-vars/action.yml
@@ -35,10 +35,17 @@ runs:
         - name: Parse version variables
           id: parse
           shell: bash
+          # Inputs are read through the environment rather than interpolated into the script:
+          # `${{ }}` is expanded before bash sees the line, so a value carrying a quote or a
+          # command substitution would be executed as code instead of compared as a string.
+          env:
+              KEYCLOAK_VERSION: ${{ inputs.keycloak_version }}
+              INCLUDE_OPTIMIZED: ${{ inputs.include_optimized }}
+              INCLUDE_IMAGE_TYPE: ${{ inputs.include_image_type }}
           run: |
               set -euo pipefail
 
-              version_name="${{ inputs.keycloak_version }}"       # e.g. "24-hub", "24-prem", "24-quay", or "24-quay-optimized"
+              version_name="${KEYCLOAK_VERSION}"                  # e.g. "24-hub", "24-prem", "24-quay", or "24-quay-optimized"
 
               # Handle quay-optimized case first
               if [[ "$version_name" == *"-quay-optimized" ]]; then
@@ -53,7 +60,7 @@ runs:
               base_type="${version_name##*-}"                     # e.g. "hub", "prem", "quay"
 
               # Set image_type for provider check if requested
-              if [[ "${{ inputs.include_image_type }}" == "true" ]]; then
+              if [[ "${INCLUDE_IMAGE_TYPE}" == "true" ]]; then
                 if [[ "$base_type" == "quay" ]]; then
                   image_type="quay"
                 else
@@ -63,14 +70,14 @@ runs:
                 image_type=""
               fi
 
-              echo "version_name=${{ inputs.keycloak_version }}" | tee -a "$GITHUB_OUTPUT"
+              echo "version_name=${KEYCLOAK_VERSION}" | tee -a "$GITHUB_OUTPUT"
               echo "base_version=$base_version" | tee -a "$GITHUB_OUTPUT"
               echo "base_type=$base_type" | tee -a "$GITHUB_OUTPUT"
 
-              if [[ "${{ inputs.include_optimized }}" == "true" ]]; then
+              if [[ "${INCLUDE_OPTIMIZED}" == "true" ]]; then
                 echo "is_optimized=$is_optimized" | tee -a "$GITHUB_OUTPUT"
               fi
 
-              if [[ "${{ inputs.include_image_type }}" == "true" ]]; then
+              if [[ "${INCLUDE_IMAGE_TYPE}" == "true" ]]; then
                 echo "image_type=$image_type" | tee -a "$GITHUB_OUTPUT"
               fi

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -46,8 +46,12 @@ jobs:
         steps:
             - name: Display notify_back_error_message if present
               if: ${{ inputs.notify_back_error_message != '' }}
+              # The message is forwarded by `rerun-failed-run` from the logs of the failed run,
+              # so its content is not ours. Interpolating it into the script would run it as code.
+              env:
+                  NOTIFY_BACK_ERROR_MESSAGE: ${{ inputs.notify_back_error_message }}
               run: |
-                  echo "A previous workflow failed but has attempted to retry: ${{ inputs.notify_back_error_message }}"
+                  echo "A previous workflow failed but has attempted to retry: ${NOTIFY_BACK_ERROR_MESSAGE}"
                   exit 1
 
     list-keycloak-versions:
@@ -675,6 +679,11 @@ jobs:
 
             - name: Retag and push the image
               shell: bash
+              # `github.ref_name` is the tag that triggered the run. It reaches the script through
+              # the environment because a tag name is free-form text: interpolated, a quote in it
+              # would close the string below and the rest would run as code.
+              env:
+                  REF_NAME: ${{ github.ref_name }}
               run: |
                   set -euo pipefail
 
@@ -705,7 +714,9 @@ jobs:
                   fi
 
                   : # remove keycloak- prefix
-                  suffix_version=$(echo '${{ github.ref_name }}' | sed 's/keycloak-[0-9]*-//')
+                  : # shortest-prefix removal, so `keycloak-23-2026-08-13-001` becomes
+                  : # `2026-08-13-001` and a tag without the prefix is left untouched
+                  suffix_version="${REF_NAME#keycloak-*-}"
 
                   # Create tags with appropriate prefix
                   docker buildx imagetools create \

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,45 @@
+---
+# =============================================================================
+# zizmor.yml — GitHub Actions supply-chain policy for camunda/keycloak
+#
+# Consumed by the `zizmor` pre-commit hook (see .pre-commit-config.yaml), which
+# runs locally on `pre-commit run -a` and in CI through lint-global.
+#
+# Mirrors the policy adopted in camunda/infraex-common-config#562, itself
+# mirroring camunda/infra-global-github-actions#781.
+#
+# The binding constraint is not our own threat model but GitHub's `Require
+# actions to be pinned to a full-length commit SHA` setting, which this
+# repository enforces and which grants no exemption:
+#
+#   "all actions must be pinned to a full-length commit SHA to be used. This
+#    includes actions from your organization and actions authored by GitHub.
+#    Reusable workflows can still be referenced by tag."
+#
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+#
+# That check is evaluated over the whole dependency tree at `Set up job`, so a
+# tag left inside a third-party composite action refuses the job before any step
+# runs. That is exactly how `build-images.yml` was blocked twice this month, at
+# `rerun-failed-jobs` and then at `read-build-image-output` (fixed by #629, #630
+# and #632): both times the offending reference was two levels down, inside an
+# action this repository already pins by SHA.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+# =============================================================================
+
+rules:
+    unpinned-uses:
+        config:
+            # `policies` maps action-owner globs to a pinning level.
+            #
+            #   any       — no constraint; any ref (SHA, tag, branch) is accepted.
+            #   ref-pin   — must carry an explicit ref, symbolic (tag/branch) or SHA.
+            #   hash-pin  — must be a 40-character commit SHA. Tags and branches fail.
+            #
+            # Local references (`uses: ./.github/actions/...`) are same-repo and are
+            # skipped by this audit entirely, so they need no policy entry.
+            policies:
+                # Everything is hash-pinned, with no namespace exemption, including
+                # `actions/*` and this organisation's own repositories.
+                '*': hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,29 @@ repos:
       hooks:
           - id: actionlint-docker
 
+    - repo: https://github.com/zizmorcore/zizmor-pre-commit
+      rev: v1.29.0
+      hooks:
+          # Static analysis of GitHub Actions workflows and actions, mirroring the hook adopted
+          # in camunda/infraex-common-config#551. It covers what actionlint does not: injection
+          # through template expansion, excessive GITHUB_TOKEN permissions, credential
+          # persistence and unpinned action references. actionlint also only reads
+          # `.github/workflows/`, so `.github/actions/` was linted by nothing until now.
+          #
+          # Threshold is `high` because the repository still carries medium and low findings
+          # (mostly `artipacked` and `${{ steps.*.outputs }}` interpolation); `high` is clean as
+          # of this commit and is what keeps it that way.
+          #
+          # Without GH_TOKEN zizmor runs offline, which skips known-vulnerable-actions,
+          # impostor-commit, ref-confusion, ref-version-mismatch and stale-action-refs.
+          # None of those currently report anything at `high`.
+          #
+          # --config makes the pinning policy explicit in .github/zizmor.yml rather than leaving
+          # it to zizmor's defaults, so a future default change cannot silently drop
+          # `unpinned-uses` below the threshold above.
+          - id: zizmor
+            args: [--no-progress, --min-severity=high, --config=.github/zizmor.yml]
+
     - repo: https://github.com/renovatebot/pre-commit-hooks
       rev: 44.27.0
       hooks:


### PR DESCRIPTION
Rolls the zizmor pre-commit hook adopted in camunda/infraex-common-config#551 / #562 out to this repository, and clears the findings it reports at the `high` threshold.

## Why zizmor on top of actionlint

They do not overlap. actionlint checks workflow syntax and runs shellcheck on `run:` blocks; zizmor audits the security semantics — template injection, `GITHUB_TOKEN` scope, credential persistence, action pinning. Two concrete gaps this closes:

- **actionlint only reads `.github/workflows/`.** `.github/actions/compose/action.yml` and `.github/actions/extract-version-vars/action.yml` were linted by nothing at all. Five of the seven findings below are in the latter.
- **The pinning rule that broke CI twice this month is not something actionlint models.** `rerun-failed-jobs` (run 31546370733) and `read-build-image-output` (run 31682777896, the `2026-08-13-001` release build) were both refused at `Set up job` by GitHub's SHA-pinning requirement, evaluated over the whole dependency tree, for references two levels below anything this repository writes. #629, #630 and #632 fixed the instances; `unpinned-uses` is what detects the next one locally.

## Findings fixed

**`build-images.yml:50` — `triage`, High.** `${{ inputs.notify_back_error_message }}` was interpolated straight into bash. That string is not ours: `rerun-failed-run` extracts it from the logs of the failed run and dispatches it back into this workflow. Now passed through `env:`.

**`build-images.yml:712` — `publish-image`, High.** `'${{ github.ref_name }}'` inside single quotes; a tag containing a quote closes the string and the rest of the line runs as code. Now passed through `env:`.

The `echo | sed` pair it fed also had to go: with the value no longer expanded literally, shellcheck sees the pipeline and reports SC2001. Replaced by shortest-prefix removal, verified equivalent on every tag shape the workflow accepts:

| tag | `sed 's/keycloak-[0-9]*-//'` | `${REF_NAME#keycloak-*-}` |
| --- | --- | --- |
| `keycloak-23-2026-08-13-001` | `2026-08-13-001` | `2026-08-13-001` |
| `2026-08-13-001` | `2026-08-13-001` | `2026-08-13-001` |

**`extract-version-vars/action.yml` — 5 × High.** The three inputs were interpolated into five shell conditionals. Repository-controlled today (they come from the matrix), but this is a composite action: the guarantee is the caller's, not the action's. Now read from `env:`.

## Configuration

`--min-severity=high` matches infraex-common-config. The repository still carries medium and low findings — 8 `artipacked` (checkouts without `persist-credentials: false`) and a set of `${{ steps.*.outputs }}` interpolations — which are a separate follow-up; `high` is clean as of this commit and stays that way.

`.github/zizmor.yml` pins the `unpinned-uses` policy to `hash-pin` for every namespace, including `actions/*` and `camunda/*`. It changes no finding today — the repository is already fully SHA-pinned — it stops a future change of zizmor's default from silently dropping that audit below the threshold.

Without `GH_TOKEN` zizmor runs offline, which skips `known-vulnerable-actions`, `impostor-commit`, `ref-confusion`, `ref-version-mismatch` and `stale-action-refs`. None of those reports anything at `high` here.

## Verification

`pre-commit run --all-files` is clean, zizmor hook included. The `extract-version-vars` change is exercised by every `build-image`, `test-base-image` and `publish-image` job in this run; the `triage` change only fires on the notify-back path, and the `publish-image` change only on tags, so both are covered by review rather than by CI.
