### PR TITLE
fix(release): baseline on the last published tag, not the last tag [ready]

### DIFF
--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -27,32 +27,95 @@ permissions:
 jobs:
     check-changes:
         runs-on: ubuntu-latest
+        # The baseline step reads the build-images runs of past tags through the API, which needs
+        # `actions: read` on top of the workflow-level `contents: read`.
+        permissions:
+            contents: read
+            actions: read
         outputs:
             has_changes: ${{ steps.check.outputs.has_changes }}
+            baseline_tag: ${{ steps.baseline.outputs.baseline_tag }}
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:
                   fetch-depth: 0
 
-            - name: Check for relevant changes since last release
-              id: check
+            # A release tag is created before the images it names exist: `build-images.yml` only
+            # starts once the tag is pushed, and it can fail. Taking the newest tag as the
+            # baseline therefore counts a failed build as "already released", and the guard below
+            # then reports no change and never retries it. That is what happened to
+            # 2026-08-13-001, refused at `read-build-image-output`: nothing was published and the
+            # next scheduled run would have found nothing to do either.
+            #
+            # The baseline is the newest tag whose build-images run completed successfully, i.e.
+            # the newest tag whose images are actually on the registries.
+            - name: Resolve the last successfully published release tag
+              id: baseline
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
                   set -euo pipefail
 
-                  # Get the latest release tag
-                  last_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // empty')
+                  baseline=""
+                  building=""
 
-                  echo "Checking changes since tag: ${last_tag}"
-                  changed_files=$(git diff --name-only "${last_tag}..HEAD")
+                  while read -r tag; do
+                    [ -n "${tag}" ] || continue
+
+                    run=$(gh run list --workflow build-images.yml --branch "${tag}" --limit 1 \
+                      --json status,conclusion --jq '.[0] | "\(.status)/\(.conclusion // "")"')
+
+                    echo "${tag}: ${run:-no run found}"
+
+                    case "${run}" in
+                      completed/success)
+                        baseline="${tag}"
+                        break
+                        ;;
+                      completed/*|'')
+                        : # failed, cancelled or never built: its images are missing, look further back
+                        ;;
+                      *)
+                        : # queued or running: its outcome decides whether a new tag is needed at
+                        : # all, so defer rather than stack a second release on top of it
+                        building="${tag}"
+                        break
+                        ;;
+                    esac
+                  done < <(gh release list --limit 20 --json tagName --jq '.[].tagName')
+
+                  echo "baseline_tag=${baseline}" | tee -a "$GITHUB_OUTPUT"
+                  echo "building_tag=${building}" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Check for relevant changes since the last successful release
+              id: check
+              env:
+                  BASELINE_TAG: ${{ steps.baseline.outputs.baseline_tag }}
+                  BUILDING_TAG: ${{ steps.baseline.outputs.building_tag }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -n "${BUILDING_TAG}" ]; then
+                    echo "::notice::${BUILDING_TAG} is still building; deferring to the next run."
+                    echo "has_changes=false" | tee -a "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  if [ -z "${BASELINE_TAG}" ]; then
+                    echo "::warning::None of the last 20 releases has a successful build-images run; releasing so the images get rebuilt."
+                    echo "has_changes=true" | tee -a "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  echo "Checking changes since tag: ${BASELINE_TAG}"
+                  changed_files=$(git diff --name-only "${BASELINE_TAG}..HEAD")
 
                   # Check if any keycloak bases.yml or Dockerfile* files were changed
                   if echo "$changed_files" | grep -qE '^keycloak-[0-9]+/(bases\.yml|Dockerfile)'; then
-                    echo "has_changes=true" >> "$GITHUB_OUTPUT"
+                    echo "has_changes=true" | tee -a "$GITHUB_OUTPUT"
                   else
-                    echo "has_changes=false" >> "$GITHUB_OUTPUT"
+                    echo "has_changes=false" | tee -a "$GITHUB_OUTPUT"
                   fi
 
     release:
@@ -83,6 +146,7 @@ jobs:
             - name: Create GitHub Release
               env:
                   GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+                  BASELINE_TAG: ${{ needs.check-changes.outputs.baseline_tag }}
               run: |
                   set -euo pipefail
 
@@ -108,16 +172,18 @@ jobs:
 
                   release_tag="${today}-$(printf '%03d' "${next_number}")"
 
-                  # Verify there are commits since the last release
-                  last_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // empty')
-                  if [ -n "${last_tag}" ]; then
-                    if ! gh api "repos/${{ github.repository }}/git/ref/tags/${last_tag}" --jq '.object.sha' >/dev/null 2>&1; then
-                      echo "::error::Last release tag ${last_tag} not found via API."
+                  # Verify there are commits since the last successfully published release.
+                  # Same baseline as check-changes: comparing against the newest tag instead
+                  # would exit here whenever the previous build failed on the current commit,
+                  # which is precisely the case this release is meant to retry.
+                  if [ -n "${BASELINE_TAG}" ]; then
+                    if ! gh api "repos/${{ github.repository }}/git/ref/tags/${BASELINE_TAG}" --jq '.object.sha' >/dev/null 2>&1; then
+                      echo "::error::Baseline release tag ${BASELINE_TAG} not found via API."
                       exit 1
                     fi
-                    commit_count=$(gh api "repos/${{ github.repository }}/compare/${last_tag}...${{ github.sha }}" --jq '.total_commits')
+                    commit_count=$(gh api "repos/${{ github.repository }}/compare/${BASELINE_TAG}...${{ github.sha }}" --jq '.total_commits')
                     if [ "${commit_count}" -eq 0 ]; then
-                      echo "No new commits since last release ${last_tag}, skipping."
+                      echo "No new commits since last published release ${BASELINE_TAG}, skipping."
                       exit 0
                     fi
                   fi


### PR DESCRIPTION
## The gap

`release-keycloak-upgrade.yml` creates a release tag; `build-images.yml` then picks the tag up and publishes the images. The tag therefore exists *before* the images do, and the build can fail — but `check-changes` compared against the newest tag regardless:

```bash
last_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // empty')
changed_files=$(git diff --name-only "${last_tag}..HEAD")
```

A failed build thus counts as "already released". The next scheduled run diffs against a tag whose images were never pushed, sees no change, and exits. The release is never retried and the hole is permanent.

It also short-circuits one level down: the `release` job's *"Verify there are commits since the last release"* guard used the same newest-tag baseline, so even a forced re-run would have exited with `No new commits since last release` on the very commit it was meant to republish.

## Not hypothetical

`2026-08-13-001` was refused at `read-build-image-output` ([run 31682777896](https://github.com/camunda/keycloak/actions/runs/31682777896)) — the unpinned transitive actions in `cloudposse/github-action-matrix-outputs-read`, fixed by #632 one minute after that run started. `publish-image` was skipped; nothing was published.

The only diff between `2026-07-28-001` and that tag is inside `keycloak-26/Dockerfile`, i.e. exactly the pattern the guard matches — so with the old logic tomorrow's run would have found nothing to do, and no run after it ever would have either. The content happened to be comment-only this time (the two `hadolint ignore=DL3066` blocks from #631). A base image bump for a CVE would have been dropped the same way, silently.

## The fix

The baseline is now the newest release tag whose `build-images` run actually completed successfully — the newest tag whose images are on the registries. The last 20 releases are walked newest-first:

| run state for the tag | decision |
| --- | --- |
| `completed/success` | baseline found, stop |
| `completed/failure`, `completed/cancelled`, no run | images missing, keep looking further back |
| queued or in progress | defer to the next scheduled run |
| nothing successful in 20 releases | release anyway, with a `::warning::` |

The "still building" case matters on a daily schedule with a ~40 min build: its outcome is what decides whether a new tag is needed at all, so stacking a second release on top of it would be guessing.

The same `baseline_tag` is passed to the `release` job so both guards agree.

## Verification

Replayed against the current state of the repository:

```
2026-08-13-001: completed/failure
2026-07-28-001: completed/success
baseline=2026-07-28-001

git diff --name-only 2026-07-28-001..main | grep -E '^keycloak-[0-9]+/(bases\.yml|Dockerfile)'
keycloak-26/Dockerfile          -> has_changes=true

gh api compare/2026-07-28-001...main --jq .total_commits
9                               -> release proceeds
```

So the next scheduled run publishes what `2026-08-13-001` failed to publish, instead of skipping. Before this change it evaluated to `has_changes=false`.

`pre-commit run --all-files` is clean, actionlint and zizmor included.

## Permissions

`check-changes` gains `actions: read`. Listing workflow runs needs it on top of the workflow-level `contents: read` introduced in #633, and relying on the endpoint being publicly readable would be a silent dependency on the repository staying public.
