### PR TITLE
ci: stop persisting credentials and inheriting secrets needlessly [ready]

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -63,6 +63,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: List Keycloak Versions from repository's folders
               id: set-matrix
@@ -96,6 +98,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: Install asdf tools with cache
               uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
@@ -221,6 +225,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: Install asdf tools with cache
               uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
@@ -308,6 +314,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: Install build-essentials for asdf
               run: |
@@ -583,6 +591,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: Install if required common software tooling
               uses: camunda/infra-global-github-actions/common-tooling@66bf6e260f2beb42a83284fef490bb96672e8f36 # main

--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,5 +16,7 @@ concurrency:
 
 jobs:
     call-todo-checker:
+        # No `secrets: inherit`: todo-checker-global reads no secret at all, it works off
+        # GITHUB_TOKEN and the permissions it declares itself. Inheriting would hand it every
+        # secret this repository holds for nothing.
         uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
-        secrets: inherit

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,6 +25,8 @@ jobs:
             issues: write
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
 
             - name: Get Current Timestamp
               id: timestamp

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -39,6 +39,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
 
             # A release tag is created before the images it names exist: `build-images.yml` only
@@ -140,6 +141,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:
+                  # The App token still authenticates the fetch; it is simply not written to
+                  # `.git/config` afterwards. Nothing here talks to git over the network: the
+                  # release is created through the API, with the same token passed as GH_TOKEN.
+                  persist-credentials: false
                   fetch-depth: 0
                   token: ${{ steps.generate-github-token.outputs.token }}
 


### PR DESCRIPTION
Continues the zizmor burn-down started with the hook adoption. Two audits, same shape: a credential handed to something that does not need it.

## `artipacked` — `persist-credentials: false`

`actions/checkout` writes the token it authenticated with into `.git/config`, so it stays readable by every later step in the job and travels with any artifact built from the workspace. It is only needed when something afterwards talks to git over the network.

Nothing here does. Checked per site:

- no `git push`, `git fetch` or `git commit` anywhere in the repository's workflows or the scripts they call;
- the deployment actions that do push build their own authenticated remote from their `token` input rather than reusing the persisted credential — `JamesIves/github-pages-deploy-action` re-creates `origin` as `https://x-access-token:<token>@github.com/<repo>.git` (`src/util.ts:36-41` at the pinned SHA), and `rossjrw/pr-preview-action` passes its `token` input straight through to it.

So the flag is free here, and it stops being free the day someone adds an `upload-artifact` step over the workspace.

## `secrets-inherit` — half now, half after upstream

`secrets: inherit` passes **every** secret the calling repository holds to the called workflow.

`todo-checker-global` reads no secret at all — it works off `GITHUB_TOKEN` and the permissions it declares itself — so the line is simply dropped.

The `lint-global` caller keeps it for now. That workflow does read `VAULT_ADDR`, `VAULT_ROLE_ID` and `VAULT_SECRET_ID`, but declares no `secrets:` block under `workflow_call`, so a caller currently has no way to pass them explicitly. camunda/infraex-common-config#571 declares them upstream; this caller migrates to the explicit three-line form once that is released.

## Verification

`zizmor --min-severity=medium`: `artipacked` cleared, `secrets-inherit` 2 → 1. `pre-commit run --all-files` clean.


## Note on the release job

`release-keycloak-upgrade.yml` checks out with the GitHub App token minted from Vault. That token still authenticates the fetch — `persist-credentials: false` only stops it being written to `.git/config` afterwards. Nothing in that job talks to git over the network: the tag and the release are both created through the API, with the same token passed as `GH_TOKEN`.
