### PR TITLE
ci: state the permissions granted to the called workflows [ready]

### DIFF
--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,6 +16,13 @@ concurrency:
 
 jobs:
     call-todo-checker:
+        # A caller-level block is not additive: the called workflow's jobs get the intersection
+        # of what the caller grants and what they declare. `check-todos` declares exactly these
+        # two, and `pull-requests: write` is what lets it post the TODO comments -- dropping it
+        # here would silently disable them rather than fail.
+        permissions:
+            contents: read
+            pull-requests: write
         # No `secrets: inherit`: todo-checker-global reads no secret at all, it works off
         # GITHUB_TOKEN and the permissions it declares itself. Inheriting would hand it every
         # secret this repository holds for nothing.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,12 @@ on:
 
 jobs:
     lint:
+        # A caller-level block is not additive: the called workflow's jobs get the intersection
+        # of what the caller grants and what they declare. `contents: read` is exactly what
+        # lint-global declares for itself, so this states the grant without narrowing it -- and
+        # stops the job inheriting the repository default, which is write.
+        permissions:
+            contents: read
         uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
         # Explicit rather than `secrets: inherit`, which hands every secret this repository holds
         # to a workflow whose main job installs and executes third-party pre-commit hook code.


### PR DESCRIPTION
Closes the last `excessive-permissions` findings, the two reusable-workflow callers. zizmor now reports **nothing at `medium`** on this repository.

## Why they were skipped before

In #633 and the passes that followed I left these two alone, on the grounds that a caller-level `permissions` block caps the callee rather than complementing it, and would therefore break workflows I do not own.

That reasoning was half right. The called workflow's jobs receive the **intersection** of what the caller grants and what they declare — so a block that *matches* the declaration changes nothing about what the callee can do, while removing the repository default (`write`) from the job. Skipping it was leaving a write-capable `GITHUB_TOKEN` on the table for no benefit.

## What each callee actually declares

| caller | callee declares | granted here |
| --- | --- | --- |
| `lint.yml` | `contents: read` at the workflow level; the auto-fix job commits through a GitHub App token, not `GITHUB_TOKEN` | `contents: read` |
| `internal_global_pr_todo_checker.yml` | `check-todos`: `contents: read`, `pull-requests: write` | both |

`pull-requests: write` is what lets the TODO checker post its comments. Granting less would have disabled them **silently** — the job would still pass — which is why it is stated in full rather than narrowed.

## Verification

- `zizmor --min-severity=medium`: no findings at all.
- Both workflows run on this pull request, so the grants are exercised: `lint / pre-commit` and `call-todo-checker / check-todos` must be green here for this to be correct.
- The `autofix-apply` path is not exercised (it only runs for the designated bot actor), but it inherits the same `contents: read` from `lint-global` itself and creates its commit through the App token, so the caller grant is not what gates it.
