### PR TITLE
ci: retry the registry flakes the matrix actually hits

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -857,6 +857,9 @@ jobs:
                   # rerun passes. `Get "…/v2/":` is the login handshake, whatever follows it
                   # (`unauthorized:` with an empty body, `context deadline exceeded`, EOF).
                   #
+                  # The push entry names the two Harbor projects of this workflow rather than
+                  # `.*`, so it cannot swallow a push denial from docker.io.
+                  #
                   # Deliberately not listed: `denied: … will exceed the configured upper limit`,
                   # the Harbor storage quota. That one is a real, persistent condition, and
                   # retrying it only burns runner minutes and defers the alert.
@@ -864,7 +867,7 @@ jobs:
                       lost communication with the server
                       The runner has received a shutdown signal
                       Get "https://registry\.camunda\.cloud/v2/":
-                      unauthorized to access repository: .*, action: push
+                      unauthorized to access repository: (keycloak-ee|team-infrastructure-experience)/keycloak, action: push
                   run-id: ${{ github.run_id }}
                   repository: ${{ github.repository }}
                   vault-addr: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -847,9 +847,24 @@ jobs:
             - name: Retrigger job
               uses: camunda/infra-global-github-actions/rerun-failed-run@32a6e03de12f6c9c08a2e0590bb5aef2d69e9d6c # main
               with:
+                  # Matched as regexes, joined with `|`, against the logs of the failed steps and
+                  # the failure annotations of the run, by
+                  # `rerun-failed-run/check-annotations-and-logs`.
+                  #
+                  # The two registry entries cover transport and auth-service hiccups on
+                  # registry.camunda.cloud, which is the failure mode this matrix actually hits:
+                  # the same credentials succeed in the sibling jobs of the same run, and the
+                  # rerun passes. `Get "…/v2/":` is the login handshake, whatever follows it
+                  # (`unauthorized:` with an empty body, `context deadline exceeded`, EOF).
+                  #
+                  # Deliberately not listed: `denied: … will exceed the configured upper limit`,
+                  # the Harbor storage quota. That one is a real, persistent condition, and
+                  # retrying it only burns runner minutes and defers the alert.
                   error-messages: |
                       lost communication with the server
                       The runner has received a shutdown signal
+                      Get "https://registry\.camunda\.cloud/v2/":
+                      unauthorized to access repository: .*, action: push
                   run-id: ${{ github.run_id }}
                   repository: ${{ github.repository }}
                   vault-addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
The auto-retry has been dead since 2026-07-22 and came back yesterday with camunda/infra-core#13902 (camunda/camunda-deployment-references#2950). Now that it dispatches again, what it *does not* retry is visible.

## Problem

The allowlist carried the two self-hosted runner messages only:

```yaml
error-messages: |
    lost communication with the server
    The runner has received a shutdown signal
```

Not one of the failures this repository actually hit on 13 and 14 August matches them. Every one of them was a transient registry error, and every one cost a manual rerun — six of them over two days, including on pull requests whose diff could not possibly reach the failing job:

| observed | where |
| --- | --- |
| `Get "https://registry.camunda.cloud/v2/": unauthorized:` (empty body) | `Login to the registry`, [run 31711780047](https://github.com/camunda/keycloak/actions/runs/31711780047), [run 31781625185](https://github.com/camunda/keycloak/actions/runs/31781625185) |
| `Get "https://registry.camunda.cloud/v2/": context deadline exceeded` | `build-image (24-quay)`, [run 31717133074](https://github.com/camunda/keycloak/actions/runs/31717133074) |
| `unauthorized to access repository: …, action: push` | 7 of 16 `build-image` jobs, [run 31684291336](https://github.com/camunda/keycloak/actions/runs/31684291336) |

All three are transient: the same credentials succeed in the sibling jobs of the same run, and the rerun passes. A revoked credential cannot fail 7 of 16 jobs and leave the other 9 working.

The first two are the login handshake, so the pattern stops at the URL and covers whatever follows it — `unauthorized:`, `context deadline exceeded`, `EOF`, TLS timeouts.

## What is deliberately left out

- **`denied: … will exceed the configured upper limit`** — the Harbor storage quota that blocked every build on 13 August (#641). A real, persistent condition. Retrying it burns runner minutes and delays the alert.
- **`artifact … not found`** — what a registry cleanup leaves behind. Rerunning the *failed* jobs cannot fix it, since the images are missing; the whole run has to go again. Retrying would fail identically, twice.

## How the matching works

`rerun-failed-run/check-annotations-and-logs` joins the patterns with `|` and evaluates them as a **regex** (`jq test`) against the logs of the failed steps and the run's failure annotations. Hence the escaped dots.

The push entry names the two Harbor projects instead of `.*`, so it cannot run past the repository name and swallow a push denial from docker.io:

```
unauthorized to access repository: (keycloak-ee|team-infrastructure-experience)/keycloak, action: push
```

Verified against the real log lines, using the same jq expression the action runs:

| line | retry |
| --- | --- |
| login `unauthorized:` | ✅ |
| login `context deadline exceeded` | ✅ |
| push `unauthorized to access repository: team-infrastructure-experience/keycloak` | ✅ |
| push `unauthorized to access repository: keycloak-ee/keycloak` | ✅ |
| `The runner has received a shutdown signal` | ✅ (unchanged) |
| push `unauthorized to access repository: camunda/keycloak` (docker.io) | ❌ |
| `denied: requested access to the resource is denied` (docker.io) | ❌ |
| quota `denied: … upper limit of 100.0 GiB` | ❌ |
| `artifact … not found` | ❌ |
| `AssertionError: expected keycloak to be healthy` | ❌ |

## Blast radius

Unchanged and bounded: `rerun-failed-jobs` is guarded by `fromJSON(github.run_attempt) < 3`, so a pattern that matches something genuinely broken costs at most two extra attempts before the run stays red — which is also what it did before this change, just via a human.

