### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.3.4 [ready]

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -107,7 +107,7 @@ jobs:
                   persist-credentials: false
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
 
             - name: Import secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -246,7 +246,7 @@ jobs:
                   persist-credentials: false
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
 
             - name: Set Keycloak Image Name
               id: set-keycloak-image-name
@@ -351,7 +351,7 @@ jobs:
                   libreadline-dev tk tk-dev
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
 
             - name: Set Keycloak Image Name
               id: set-keycloak-image-name
@@ -651,7 +651,7 @@ jobs:
                   buildx-install: true
 
             - name: Install asdf tools with cache
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
 
             - name: Import secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -894,7 +894,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -26,4 +26,4 @@ jobs:
         # No `secrets: inherit`: todo-checker-global reads no secret at all, it works off
         # GITHUB_TOKEN and the permissions it declares itself. Inheriting would hand it every
         # secret this repository holds for nothing.
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Notify in Slack in case of failure
               id: slack-notification
               if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         # stops the job inheriting the repository default, which is write.
         permissions:
             contents: read
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
         # Explicit rather than `secrets: inherit`, which hands every secret this repository holds
         # to a workflow whose main job installs and executes third-party pre-commit hook code.
         # These three are all it reads, and only on the auto-fix path.

--- a/.github/workflows/release-keycloak-upgrade.yml
+++ b/.github/workflows/release-keycloak-upgrade.yml
@@ -229,7 +229,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@887ed647c59e94535464fdfe2cfa0f33cffee468 # 2.3.3
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
     - repo: https://github.com/camunda/infraex-common-config
-      rev: 2.3.3 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      rev: 2.3.4 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
       hooks:
           - id: update-action-readmes-docker
 


### PR DESCRIPTION
## Description

Moves every `camunda/infraex-common-config` reference in this repository to 2.3.4 (`26224a8e`).

2.3.4 carries the CI cache work merged in camunda/infraex-common-config#576 and camunda/infraex-common-config#578:

- `restore-keys` ladder and a narrower key for the pre-commit hook environments, so a Renovate hook bump reuses the environments of the hooks that did not change instead of rebuilding all of them;
- same for the asdf toolchain, whose key rotated weekly and hashed all of `.tool-versions`, so a single tool bump recompiled CPython;
- cache saves scoped to the default branch, where the entry is readable by every run, instead of one unreadable 100-150 MB entry per pull request evicting the shared one;
- the unconditional `apt-get install libsqlite3-dev libbz2-dev liblzma-dev` dropped from `lint-global`, replaced by an assertion that the interpreter can import `bz2`, `lzma` and `sqlite3`;
- bounded retries around `apt-get update`, which hung for over nine minutes and killed jobs through the job timeout on 2026-08-19, and a timeout raised from 10 to 20 minutes.

Measured on `camunda/infraex-common-config` `main`: the lint job went from 9m58 cold to 49s once both caches hit.

## Note

All references move together rather than only the ones a given workflow needs, so the repository stops running two revisions of the same toolchain.

## Verification

`actionlint` 1.7.12 is clean and the repository's own pre-commit hooks pass on the change.